### PR TITLE
Postgres isolated redo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Or, if you would like to use postgres for your database:
 	Enter password: **********
 	psql> CREATE DATABASE IF NOT EXISTS dejavu;
 
+and change the config path in example.py:9 to `dejavu-postgresql.cnf.SAMPLE`.
+
 Now you're ready to start fingerprinting your audio collection! 
 
 ## Quickstart

--- a/dejavu-postgresql.cnf.SAMPLE
+++ b/dejavu-postgresql.cnf.SAMPLE
@@ -1,0 +1,9 @@
+{
+    "database_type": "postgresql",
+    "database": {
+        "host": "127.0.0.1",
+        "user": "postgres",
+        "password": "",
+        "database": "dejavu"
+    }
+}

--- a/dejavu/database.py
+++ b/dejavu/database.py
@@ -160,13 +160,11 @@ def get_database(database_type=None):
     database_type = database_type.lower()
     if database_type == 'postgresql':
         import dejavu.database_postgres
+    if database_type == 'mysql':
+        import dejavu.database_sql
 
     for db_cls in Database.__subclasses__():
         if db_cls.type == database_type:
             return db_cls
 
     raise TypeError("Unsupported database type supplied.")
-
-
-# Import our default database handler
-import dejavu.database_sql

--- a/dejavu/database_postgres.py
+++ b/dejavu/database_postgres.py
@@ -45,7 +45,7 @@ class PostgresDatabase(Database):
     CREATE_FINGERPRINTS_TABLE = """
         CREATE TABLE IF NOT EXISTS %s (
              %s bytea NOT NULL,
-             %s uuid NOT NULL,
+             %s serial NOT NULL,
              %s int NOT NULL,
              CONSTRAINT comp_key UNIQUE (%s, %s, %s),
              FOREIGN KEY (%s) REFERENCES %s(%s)
@@ -82,7 +82,7 @@ class PostgresDatabase(Database):
     # Creates the table that stores song information.
     CREATE_SONGS_TABLE = """
         CREATE TABLE IF NOT EXISTS %s (
-            %s uuid DEFAULT uuid_generate_v4() NOT NULL,
+            %s serial NOT NULL,
             %s varchar(250) NOT NULL,
             %s boolean default FALSE,
             PRIMARY KEY (%s),

--- a/dejavu/database_sql.py
+++ b/dejavu/database_sql.py
@@ -1,10 +1,15 @@
 from __future__ import absolute_import
 from itertools import izip_longest
 import Queue
+import sys
 
-import MySQLdb as mysql
+try:
+    import MySQLdb as mysql
+except ImportError as err:
+    print "Module not installed", err
+    sys.exit(1)
+
 from MySQLdb.cursors import DictCursor
-
 from dejavu.database import Database
 
 


### PR DESCRIPTION
This commit should finish up PR [#78 on worldveil/dejavu](https://github.com/worldveil/dejavu/pull/78). I confirmed it doesn't error when MySQLdb is not installed. I added a sample config file since the variables are named a bit differently.

I also had to change the `song_id` field from a uuid to a serial, since uuid_generate_v4() is an extension module that I couldn't get to compile on Postgres 9.4.0 / OSX 10.3.
